### PR TITLE
queueing events for batch-write

### DIFF
--- a/lib/perhap/adapters/eventstore/dynamo.ex
+++ b/lib/perhap/adapters/eventstore/dynamo.ex
@@ -58,13 +58,32 @@ defmodule Perhap.Adapters.Eventstore.Dynamo do
   going to Dynamo for the event.
 
   ## Example:
-  Perhap.Adapters.Eventstore.Dynamo.get_event(event_id)
+  {:ok, %Perhap.Event{}} = Perhap.Adapters.Eventstore.Dynamo.get_event(event_id)
   """
   @spec get_event(event_id: Perhap.Event.UUIDv1) :: {:ok, Perhap.Event.t} | {:error, term}
   def get_event(event_id) do
     GenServer.call(:eventstore, {:get_event, event_id})
   end
 
+  @doc """
+  Retrieves events based on the context associated with those events.  The context
+  can be found in the event metadata (Perhap.Event.Metadata).  The results can be
+  narrowed by supplying an entity_id as an option or an after option which will only
+  retrieve events created after the supplied event_id.
+
+  Returns a list of events inside an :ok tuple response ({:ok, events}) or empty
+  {:ok, []} if no events were found.  Can return an :error tuple (:error, reason)
+  if an unknown error occurred.
+
+  ## Example:
+
+  {:ok, events} = get_events(event.metadata.context) #get all events with the same context as this event
+  {:ok []} = get_Events(:no_events_with_this_context)
+  {:ok, events} = get_events(event.metadata.context, [entity_id: event.metadata.entity_id])
+  {:ok, events} = get_events(event.metadata.context, [after: event.event_id])
+
+  """
+  
   @spec get_events(atom(), [entity_id: Perhap.Event.UUIDv4.t, after: Perhap.Event.UUIDv1.t]) :: {:ok, list(Perhap.Event.t)} | {:error, term}
   def get_events(context, opts \\ []) do
     GenServer.call(:eventstore, {:get_events, context, opts})

--- a/lib/perhap_dynamo.ex
+++ b/lib/perhap_dynamo.ex
@@ -1,18 +1,3 @@
 defmodule PerhapDynamo do
-  @moduledoc """
-  Documentation for PerhapDynamo.
-  """
 
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> PerhapDynamo.hello
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/test/perhap/adapters/eventstore/dynamo_test.exs
+++ b/test/perhap/adapters/eventstore/dynamo_test.exs
@@ -2,8 +2,12 @@ defmodule PerhapTest.Adapters.Dynamo do
   use PerhapTest.Helper, port: 4499
   alias Perhap.Adapters.Eventstore.Dynamo
 
+  @pause_interval 500
+
   setup do
     Application.put_env(:perhap, :eventstore, Perhap.Adapters.Eventstore.Dynamo, [])
+    Perhap.Adapters.Eventstore.Dynamo.start_link([])
+    :ok
   end
 
 
@@ -11,26 +15,34 @@ defmodule PerhapTest.Adapters.Dynamo do
     random_context = Enum.random([:a, :b, :c, :d, :e])
     random_event = make_random_event(
       %Perhap.Event.Metadata{context: random_context, entity_id: Perhap.Event.get_uuid_v4()} )
-    assert ExAws.Dynamo.get_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request! == %{}
+    check1 = ExAws.Dynamo.get_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request!
     Dynamo.put_event(random_event)
-    refute ExAws.Dynamo.get_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request! == %{}
+    :timer.sleep(@pause_interval)
+    check2 = ExAws.Dynamo.get_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request!
 
     #cleanup
     ExAws.Dynamo.delete_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request!
     ExAws.Dynamo.delete_item("Index", %{context: random_context, entity_id: random_event.metadata.entity_id}) |> ExAws.request!
+
+    assert check1 == %{}
+    refute check2 == %{}
   end
 
   test "get_event" do
     random_context = Enum.random([:a, :b, :c, :d, :e])
     random_event = make_random_event(
       %Perhap.Event.Metadata{context: random_context, entity_id: Perhap.Event.get_uuid_v4()} )
-    assert Dynamo.get_event(random_event.event_id) == {:error, "Event not found"}
+    check1 = Dynamo.get_event(random_event.event_id)
     Dynamo.put_event(random_event)
-    assert Dynamo.get_event(random_event.event_id) == {:ok, random_event}
+    :timer.sleep(@pause_interval)
+    check2 = Dynamo.get_event(random_event.event_id)
 
     #cleanup
     ExAws.Dynamo.delete_item("Events", %{event_id: random_event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request!
     ExAws.Dynamo.delete_item("Index", %{context: random_context, entity_id: random_event.metadata.entity_id}) |> ExAws.request!
+
+    assert check1== {:error, "Event not found"}
+    assert check2 == {:ok, random_event}
   end
 
   test "get_events with entity_id" do

--- a/test/perhap/event_test.exs
+++ b/test/perhap/event_test.exs
@@ -2,7 +2,6 @@ defmodule Perhap.EventTestDynamo do
   use ExUnit.Case, async: false
   import PerhapTest.Helper, only: :functions
 
-  @interval 1
   @pause_interval 500
 
   setup do
@@ -224,19 +223,20 @@ defmodule Perhap.EventTestDynamo do
     events = Enum.map(1..125, fn _number -> make_random_event(
       %Perhap.Event.Metadata{context: context, entity_id: random_entity}) end)
     Enum.each(events, fn event -> Perhap.Event.save_event(event) end)
-    :timer.sleep(@pause_interval)
+    :timer.sleep(4000)
+
     results = Perhap.Event.retrieve_events(context)
 
     #cleanup
-    #Enum.map(events, fn event -> ExAws.Dynamo.delete_item("Events", %{event_id: event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request! end)
-    #ExAws.Dynamo.delete_item("Index", %{context: context, entity_id: random_entity}) |> ExAws.request!
+    Enum.map(events, fn event -> ExAws.Dynamo.delete_item("Events", %{event_id: event.event_id |> Perhap.Event.uuid_v1_to_time_order}) |> ExAws.request! end)
+    ExAws.Dynamo.delete_item("Index", %{context: context, entity_id: random_entity}) |> ExAws.request!
     #/cleanup
 
     sorted_events = Enum.sort(events, fn event1, event2 -> event1.event_id >= event2.event_id end)
     with {:ok, retrieved_events} <- results do
       sorted_results = Enum.sort(retrieved_events, fn event1, event2 -> event1.event_id >= event2.event_id end)
 
-      assert Enum.count(sorted_events) == Enum.count(sorted_results)
+      assert sorted_events == sorted_results
     end
 
 


### PR DESCRIPTION
Update to the dynamo event store.  Now put_event queues an event for persistence and returns control to the calling process.  Periodically the process sends a message to remind itself to persist the events it has collected.  Passes the (modified) tests but needs additional tests to expose how dynamo handles payloads greater than the batch-write limit.

Should get_event check pending events before submitting the request to dynamo? Probably.  I had to add waits to the tests to prevent "eventual consistency" failures.

Ignore the 1ms interval, that was from my testing.  I would like to provide a way to configure the interval to persist.

Getters are still static code that blocks the calling process, which would have to change if it checked the pending events.